### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # grunt-flipcss
 
 > Flips LTR-based CSS files to RTL, or the opposite.
-
-[![Build Status](https://travis-ci.org/behrang/grunt-flipcss.png?branch=master)](https://travis-ci.org/behrang/grunt-flipcss)
-[![Dependency Status](https://gemnasium.com/behrang/grunt-flipcss.png)](https://gemnasium.com/behrang/grunt-flipcss)
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/behrang/grunt-flipcss/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+> This repository is a replication of behrang/grunt-flipcss for the sake of correct installation by npm. In fact installation of "grunt-flipcss" npm package results in installation of incorrect version of this repository which used "inverter" library not "flipcss" library.
 
 ## Getting Started
 This plugin requires Grunt `~0.4.1`
@@ -12,13 +9,13 @@ This plugin requires Grunt `~0.4.1`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-flipcss --save-dev
+npm install grunt-flipcss2 --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('grunt-flipcss');
+grunt.loadNpmTasks('grunt-flipcss2');
 ```
 
 ## The "flipcss" task

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This plugin requires Grunt `~0.4.1`
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install grunt-flipcss2 --save-dev
+npm install grunt-flipcss2
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-cli": "~0.1.9"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
