### PR TITLE
would like to run flipcss.clean

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,14 @@ module.exports = function(grunt) {
           'tmp/flipSelectors.css': 'test/fixtures/flipSelectors.css',
         }
       },
+      cleanDirection: {
+        options: {
+          cleanDirection: 'rtl'
+        },
+        files: {
+          'tmp/cleanDirection.css': 'test/fixtures/cleanDirection.css',
+        }
+      }
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ Default value: `true`
 
 If words left and right inside selectors should be flipped.
 
+#### options.cleanDirection
+Type: `string`
+Default value: `null`
+Possible values: `rtl` or `ltr`
+
+see: https://github.com/oyvindeh/flipcss#what-is-done-when-cleaning
+
+
 
 ### Usage Examples
 

--- a/tasks/flipcss.js
+++ b/tasks/flipcss.js
@@ -19,7 +19,7 @@ module.exports = function(grunt) {
       flipPseudo: false,
       flipUrls: true,
       flipSelectors: true,
-      cleanDirection: 'rtl'
+      cleanDirection: null
     });
 
     // Iterate over all specified file groups.

--- a/tasks/flipcss.js
+++ b/tasks/flipcss.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
       warnings: false,
       flipPseudo: false,
       flipUrls: true,
-      flipSelectors: true
+      flipSelectors: true,
+      cleanDirection: 'rtl'
     });
 
     // Iterate over all specified file groups.
@@ -39,6 +40,11 @@ module.exports = function(grunt) {
 
       // Flip file.
       src = flipcss.flip(src, options.warnings, options.flipPseudo, options.flipUrls, options.flipSelectors);
+
+      //clean
+      if (options.cleanDirection) {
+        src = flipcss.clean(src, options.cleanDirection);
+      }
 
       // Write the destination file.
       grunt.file.write(f.dest, src);

--- a/test/expected/cleanDirection.css
+++ b/test/expected/cleanDirection.css
@@ -1,0 +1,3 @@
+body{direction:rtl;}.sample {
+  color: red;
+}

--- a/test/fixtures/cleanDirection.css
+++ b/test/fixtures/cleanDirection.css
@@ -1,0 +1,3 @@
+.sample {
+  color: red;
+}

--- a/test/flipcss_test.js
+++ b/test/flipcss_test.js
@@ -58,5 +58,14 @@ exports.flipcss = {
     test.equal(actual, expected, 'should flip right and left in selectors.');
 
     test.done();
+  },
+  cleanDirection: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/cleanDirection.css');
+    var expected = grunt.file.read('test/expected/cleanDirection.css');
+    test.equal(actual, expected, 'should run flipcss.clean');
+
+    test.done();
   }
 };


### PR DESCRIPTION
see lines 22 and 45

i need to run flipcss.clean, think it would make a nice option?

i think most people would want to run flipcss.clean by default (hence line 22)... but we could take that out if you think it should not be there by default
